### PR TITLE
Add content-type header for javascript files

### DIFF
--- a/src/incppect.cpp
+++ b/src/incppect.cpp
@@ -66,6 +66,13 @@ struct Incppect<SSL>::Impl {
         uWS::WebSocket<SSL, true> * ws = nullptr;
     };
 
+    inline bool hasExt(std::string_view file, std::string_view ext) {
+        if (ext.size() > file.size()) {
+            return false;
+        }
+        return std::equal(ext.rbegin(), ext.rend(), file.rbegin());
+    }
+
     void run() {
         mainLoop = uWS::Loop::get();
 
@@ -278,6 +285,10 @@ struct Incppect<SSL>::Impl {
             if (str.size() == 0) {
                 res->end("Resource not found");
                 return;
+            }
+
+            if (hasExt(req->getUrl(), ".js")) {
+                res->writeHeader("Content-Type", "text/javascript");
             }
 
             res->end(str);


### PR DESCRIPTION
Serving javascript files with incppect results in the following warning in the firefox javascript console.

```
The script from <some javascript url> was loaded even though its MIME type (“”) is not a valid JavaScript MIME type.
```

Also, if you attempt to load a web worker, it blocks it with this message.

```
Loading Worker from <some web worker js url> was blocked because of a disallowed MIME type (“”).
```

This PR adds the javascript content-type to the header for those files which avoids the warnings and allows web workers to be loaded.