### PR TITLE
Add checks when stopping and close client sockets

### DIFF
--- a/src/incppect.cpp
+++ b/src/incppect.cpp
@@ -506,9 +506,18 @@ void Incppect<SSL>::run(Parameters parameters) {
 
 template <bool SSL>
 void Incppect<SSL>::stop() {
-    m_impl->mainLoop->defer([this]() {
-        us_listen_socket_close(0, m_impl->listenSocket);
-    });
+    if (m_impl->mainLoop != nullptr) {
+        m_impl->mainLoop->defer([this]() {
+            for (auto sd : m_impl->socketData) {
+                if (sd.second->mainLoop != nullptr) {
+                    sd.second->mainLoop->defer([sd]() {
+                        sd.second->ws->close();
+                    });
+		}
+            }
+            us_listen_socket_close(0, m_impl->listenSocket);
+        });
+    }
 }
 
 template <bool SSL>


### PR DESCRIPTION
In some cases we want another process to manage incppect rather than having console access or sending signals to get it to exit. There is also the possibility in a multi-threaded environment that `stop()` gets called more than one time, requiring us to safe-guard the access to `mainLoop`.  Also, if we just `us_listen_socket_close()`, connected websockets can cause us to hang. Looping through connected sockets and calling `close()` closes these sockets and lets us exit gracefully.